### PR TITLE
Fix crash when category is changed when search filter is active

### DIFF
--- a/FalconBMS Alternative Launcher Cs/MainWindowKeyMapping.cs
+++ b/FalconBMS Alternative Launcher Cs/MainWindowKeyMapping.cs
@@ -592,8 +592,12 @@ namespace FalconBMS_Alternative_Launcher_Cs
         {
             KeyMappingGrid.UnselectAllCells();
             string filter = SearchBox.Text.Trim().ToLower();
+            var isFilterEmpty = String.IsNullOrWhiteSpace(filter);
 
-            KeyMappingGrid.Items.Filter = x => String.IsNullOrWhiteSpace(filter) || ((KeyAssgn) x).Mapping.Trim().ToLower().Contains(filter);
+            // Enable the category selector only if there's no search filter active.
+            Category.IsEnabled = isFilterEmpty;
+
+            KeyMappingGrid.Items.Filter = x => isFilterEmpty || ((KeyAssgn) x).Mapping.Trim().ToLower().Contains(filter);
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes the following reported issue:

https://www.benchmarksims.org/forum/showthread.php?31774-Falcon-BMS-Alternative-Launcher-(Easy-Setup-Keep-Joystick-Assignments)&p=498153&viewfull=1#post498153

>The launcher crashes if you have something in the search field and then try to select a category.

by disabling the category dropdown when the filter is active.