### PR TITLE
Allow pitch and roll to be inverted

### DIFF
--- a/FalconBMS Alternative Launcher Cs/AxisAssignWindow.xaml.cs
+++ b/FalconBMS Alternative Launcher Cs/AxisAssignWindow.xaml.cs
@@ -94,7 +94,6 @@ namespace FalconBMS_Alternative_Launcher_Cs
                 case "Roll":
                     DirectionDecrease.Content = "Left Wing Down";
                     DirectionIncrease.Content = "Right Wing Down";
-                    Invert.Visibility = Visibility.Collapsed;
                     break;
                 case "Trim_Roll":
                     DirectionDecrease.Content = "Left Wing Down";
@@ -103,7 +102,6 @@ namespace FalconBMS_Alternative_Launcher_Cs
                 case "Pitch":
                     DirectionDecrease.Content = "Pitch Down";
                     DirectionIncrease.Content = "Pitch Up";
-                    Invert.Visibility = Visibility.Collapsed;
                     break;
                 case "Trim_Pitch":
                     DirectionDecrease.Content = "Pitch Down";


### PR DESCRIPTION
BMS supports inverting the pitch and roll axes, and some users might
want to do so. (A friend of mine, for example, had his pitch axis
inverted by some recent driver update. Lacking the ability to invert
pitch in the Alt Launcher, he has to manually check the "Reversed" box
in BMS controls each time he starts the game.)

Tested with BMS 4.34U2.