### PR TITLE
Sort theater list, ignore blank lines.

### DIFF
--- a/FalconBMS Alternative Launcher Cs/MainWindow.xaml.cs
+++ b/FalconBMS Alternative Launcher Cs/MainWindow.xaml.cs
@@ -117,7 +117,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
             try
             {
                 // Read Theater List
-                TheaterList theaterlist = new TheaterList(appReg, this.Dropdown_TheaterList);
+                TheaterList.Populate(appReg, this.Dropdown_TheaterList);
 
                 // Get Devices
                 deviceControl = new DeviceControl(appReg);


### PR DESCRIPTION
The previous logic that populated the theater list would sometimes leave
empty lines in the combo box. Strip out empty lines and comments, and
sort the list while we're at it.

Given the following TDF:
```
# LIST OF ALL KNOWN THEATERS
Terrdata\theaterdefinition\Korea KTO.tdf
Add-On Korea TvT\Terrdata\theaterdefinition\Korea_TvT.tdf
Add-On Kurile\TerrData\TheaterDefinition\Kurile.tdf
Add-On LoriKTO\Terrdata\theaterdefinition\LoriKTO.tdf
Add-On Kuwait UOAF\Terrdata\theaterdefinition\kuwait.tdf
Add-On Kuwait\Terrdata\theaterdefinition\kuwait.tdf <newline here>
```
1.50 displays:
![before](https://user-images.githubusercontent.com/493463/75100751-ea1d7880-5586-11ea-973c-d69c3c06682d.png)

After this patch:
![after](https://user-images.githubusercontent.com/493463/75100756-f9042b00-5586-11ea-8fcc-4699d482580b.png)
