### PR TITLE
Less stringly typed axes

### DIFF
--- a/FalconBMS Alternative Launcher Cs/AxAssgn.cs
+++ b/FalconBMS Alternative Launcher Cs/AxAssgn.cs
@@ -11,49 +11,31 @@ namespace FalconBMS_Alternative_Launcher_Cs
     /// </summary>
     public class AxAssgn
     {
-        // Member
-        protected string axisName = "";     // ex:Roll, Pitch, Yaw etc...
-        protected System.DateTime assgnDate = DateTime.Parse("12/12/1998 12:00:00");
-        protected bool invert = false;
-        protected AxCurve saturation = 0;
-        protected AxCurve deadzone = 0;
-
         // Property for XML
-        public string AxisName { get { return this.axisName; } set { this.axisName = value; } }
-        public DateTime AssgnDate { get { return this.assgnDate; } set { this.assgnDate = value; } }
-        public bool Invert { get { return this.invert; } set { this.invert = value; } }
-        public AxCurve Saturation { get { return this.saturation; } set { this.saturation = value; } }
-        public AxCurve Deadzone { get { return this.deadzone; } set { this.deadzone = value; } }
+        public AxisName? AxisName { get; set; }
+        public DateTime AssignDate { get; set; }
+        public bool Invert { get; set; }
+        public AxCurve Saturation { get; set; }
+        public AxCurve Deadzone { get; set; }
 
         // Constructor
         public AxAssgn() { }
-        public AxAssgn(String axisName, InGameAxAssgn axisassign)
-        {
-            this.axisName = axisName;
-            this.assgnDate = DateTime.Now;
-            this.invert = axisassign.GetInvert();
-            this.saturation = axisassign.GetSaturation();
-            this.deadzone = axisassign.GetDeadzone();
-        }
-        public AxAssgn(String axisName, DateTime assgnDate, bool invert, AxCurve saturation, AxCurve deadzone)
-        {
-            this.axisName = axisName;
-            this.assgnDate = assgnDate;
-            this.invert = invert;
-            this.saturation = saturation;
-            this.deadzone = deadzone;
-        }
+        public AxAssgn(AxisName axisName, InGameAxAssgn axisassign) :
+            this(axisName, DateTime.Parse("12/12/1998 12:00:00"), axisassign.GetInvert(), axisassign.GetSaturation(), axisassign.GetDeadzone())
+        { }
 
-        // Method
-        public string GetAxisName() { return this.axisName; }
-        public DateTime GetAssignDate() { return this.assgnDate; }
-        public bool GetInvert() { return this.invert; }
-        public AxCurve GetDeadZone() { return this.deadzone; }
-        public AxCurve GetSaturation() { return this.saturation; }
+        public AxAssgn(AxisName? axisName, DateTime assgnDate, bool invert, AxCurve saturation, AxCurve deadzone)
+        {
+            this.AxisName = axisName;
+            this.AssignDate = assgnDate;
+            this.Invert = invert;
+            this.Saturation = saturation;
+            this.Deadzone = deadzone;
+        }
 
         public AxAssgn Clone()
         {
-            return new AxAssgn(this.axisName, this.assgnDate, this.invert, this.saturation, this.deadzone);
+            return new AxAssgn(this.AxisName, this.AssignDate, this.Invert, this.Saturation, this.Deadzone);
         }
     }
 

--- a/FalconBMS Alternative Launcher Cs/DeviceControl.cs
+++ b/FalconBMS Alternative Launcher Cs/DeviceControl.cs
@@ -32,9 +32,6 @@ namespace FalconBMS_Alternative_Launcher_Cs
             this.devList = Manager.GetDevices(DeviceClass.GameControl, EnumDevicesFlags.AttachedOnly);
             this.joyStick = new Device[devList.Count];
             this.joyAssign = new JoyAssgn[devList.Count];
-
-            System.Xml.Serialization.XmlSerializer serializer;
-            System.IO.StreamReader sr;
             string fileName = "";
             string stockFileName = "";
             int i = 0;
@@ -54,10 +51,17 @@ namespace FalconBMS_Alternative_Launcher_Cs
                 // Load exsisting .xml files.
                 if (File.Exists(fileName))
                 {
-                    serializer = new System.Xml.Serialization.XmlSerializer(typeof(JoyAssgn));
-                    sr = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false));
-                    joyAssign[i] = (JoyAssgn)serializer.Deserialize(sr);
-                    sr.Close();
+                    try
+                    {
+                        var serializer = new System.Xml.Serialization.XmlSerializer(typeof(JoyAssgn));
+                        using (var reader = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false)))
+                            joyAssign[i] = (JoyAssgn)serializer.Deserialize(reader);
+                    }
+                    catch
+                    {
+                        // If the XML couldn't be deserialized for any reason, delete the file and fall back to stock setup.
+                        File.Delete(fileName);
+                    }
                 }
                 else
                 {
@@ -67,10 +71,9 @@ namespace FalconBMS_Alternative_Launcher_Cs
                     {
                         File.Copy(stockFileName, fileName);
 
-                        serializer = new System.Xml.Serialization.XmlSerializer(typeof(JoyAssgn));
-                        sr = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false));
-                        joyAssign[i] = (JoyAssgn)serializer.Deserialize(sr);
-                        sr.Close();
+                        var serializer = new System.Xml.Serialization.XmlSerializer(typeof(JoyAssgn));
+                        using (var reader = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false)))
+                            joyAssign[i] = (JoyAssgn)serializer.Deserialize(reader);
                     }
                 }
                 joyAssign[i].SetDeviceInstance(dev);
@@ -98,23 +101,37 @@ namespace FalconBMS_Alternative_Launcher_Cs
             }
             
             // Load MouseWheel .xml file.
-            serializer = new System.Xml.Serialization.XmlSerializer(typeof(AxAssgn));
             fileName = appReg.GetInstallDir() + "/User/Config/Setup.v100.Mousewheel.xml";
             if (File.Exists(fileName))
             {
-                sr = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false));
-                mouseWheelAssign = (AxAssgn)serializer.Deserialize(sr);
-                sr.Close();
+                try
+                {
+                    var serializer = new System.Xml.Serialization.XmlSerializer(typeof(AxAssgn));
+                    using (var reader = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false)))
+                        mouseWheelAssign = (AxAssgn)serializer.Deserialize(reader);
+                }
+                catch
+                {
+                    // If the XML couldn't be deserialized for any reason, delete the file and fall back to stock setup.
+                    File.Delete(fileName);
+                }
             }
 
             // Load ThrottlePosition .xml file.
-            serializer = new System.Xml.Serialization.XmlSerializer(typeof(ThrottlePosition));
             fileName = appReg.GetInstallDir() + "/User/Config/Setup.v100.throttlePosition.xml";
             if (File.Exists(fileName))
             {
-                sr = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false));
-                throttlePos = (ThrottlePosition)serializer.Deserialize(sr);
-                sr.Close();
+                try
+                {
+                    var serializer = new System.Xml.Serialization.XmlSerializer(typeof(ThrottlePosition));
+                    using (var reader = new System.IO.StreamReader(fileName, new System.Text.UTF8Encoding(false)))
+                        throttlePos = (ThrottlePosition)serializer.Deserialize(reader);
+                }
+                catch
+                {
+                    // If the XML couldn't be deserialized for any reason, delete the file and fall back to stock setup.
+                    File.Delete(fileName);
+                }
             }
         }
 

--- a/FalconBMS Alternative Launcher Cs/InGameAxAssgn.cs
+++ b/FalconBMS Alternative Launcher Cs/InGameAxAssgn.cs
@@ -22,10 +22,10 @@ namespace FalconBMS_Alternative_Launcher_Cs
         {
             this.devNum = devNum;
             this.phyAxNum = phyAxNum;
-            this.invert = axis.GetInvert();
-            this.saturation = axis.GetSaturation();
-            this.deadzone = axis.GetDeadZone();
-            this.assgnDate = axis.GetAssignDate();
+            this.invert = axis.Invert;
+            this.saturation = axis.Saturation;
+            this.deadzone = axis.Deadzone;
+            this.assgnDate = axis.AssignDate;
         }
 
         public InGameAxAssgn(int devNum, int phyAxNum, bool invert, AxCurve deadzone, AxCurve saturation)

--- a/FalconBMS Alternative Launcher Cs/JoyAssgn.cs
+++ b/FalconBMS Alternative Launcher Cs/JoyAssgn.cs
@@ -260,10 +260,10 @@ namespace FalconBMS_Alternative_Launcher_Cs
         /// <summary>
         /// Reset Physical axis which has assigned to "sender.name"
         /// </summary>
-        public void ResetPreviousAxis(string axisname)
+        public void ResetPreviousAxis(AxisName axisname)
         {
             for (int i = 0; i < this.axis.Length; i++)
-                if (this.axis[i].GetAxisName() == axisname)
+                if (this.axis[i].AxisName == axisname)
                     this.axis[i] = new AxAssgn();
         }
 
@@ -457,7 +457,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
                             }
 
                             InGameAxAssgn inGameAxAssgn = new InGameAxAssgn(currentID, axisNum, invert, deadzone, saturation);
-                            this.axis[axisNum] = new AxAssgn(axisMappingList[i].ToString(), inGameAxAssgn);
+                            this.axis[axisNum] = new AxAssgn(axisMappingList[i], inGameAxAssgn);
                         }
                     }
                 }

--- a/FalconBMS Alternative Launcher Cs/KeyAssgn.cs
+++ b/FalconBMS Alternative Launcher Cs/KeyAssgn.cs
@@ -313,7 +313,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
                 return "";
             ans = MainWindow.deviceControl.joyAssign[joynum].KeyMappingPreviewDX(this);
             // PRIMARY DEVICE POV
-            if (((InGameAxAssgn)MainWindow.inGameAxis["Roll"]).GetDeviceNumber() == joynum || ((InGameAxAssgn)MainWindow.inGameAxis["Throttle"]).GetDeviceNumber() == joynum)
+            if (((InGameAxAssgn)MainWindow.inGameAxis[AxisName.Roll]).GetDeviceNumber() == joynum || ((InGameAxAssgn)MainWindow.inGameAxis[AxisName.Throttle]).GetDeviceNumber() == joynum)
             {
                 string tmp = MainWindow.deviceControl.joyAssign[joynum].KeyMappingPreviewPOV(this);
                 if (ans != "" & tmp != "")
@@ -332,7 +332,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
             if(ans != "")
                 ans = "JOY " + joynum.ToString() + " " + joyAssign[joynum].KeyMappingPreviewDX(this).Replace("\n", ", ");
             // PRIMARY DEVICE POV
-            if (((InGameAxAssgn)MainWindow.inGameAxis["Roll"]).GetDeviceNumber() == joynum || ((InGameAxAssgn)MainWindow.inGameAxis["Throttle"]).GetDeviceNumber() == joynum) 
+            if (MainWindow.inGameAxis[AxisName.Roll].GetDeviceNumber() == joynum || MainWindow.inGameAxis[AxisName.Throttle].GetDeviceNumber() == joynum)
             {
                 string tmp = "";
                 tmp = joyAssign[joynum].KeyMappingPreviewPOV(this);

--- a/FalconBMS Alternative Launcher Cs/MainWindow.xaml.cs
+++ b/FalconBMS Alternative Launcher Cs/MainWindow.xaml.cs
@@ -128,7 +128,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
 
                 // Reset All Axis Settings
                 foreach (AxisName nme in axisNameList)
-                    inGameAxis[nme.ToString()] = new InGameAxAssgn();
+                    inGameAxis[nme] = new InGameAxAssgn();
                 joyAssign_2_inGameAxis();
                 ResetAssgnWindow();
 

--- a/FalconBMS Alternative Launcher Cs/OverrideSetting.cs
+++ b/FalconBMS Alternative Launcher Cs/OverrideSetting.cs
@@ -47,7 +47,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
         /// <param name="deviceControl"></param>
         /// <param name="keyFile"></param>
         /// <param name="visualAcuity"></param>
-        public void Execute(Hashtable inGameAxis, DeviceControl deviceControl, KeyFile keyFile)
+        public void Execute(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl, KeyFile keyFile)
         {
             if (!System.IO.Directory.Exists(appReg.GetInstallDir() + "/User/Config/Backup/"))
                 System.IO.Directory.CreateDirectory(appReg.GetInstallDir() + "/User/Config/Backup/");
@@ -153,7 +153,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
         /// <summary>
         /// As the name inplies...
         /// </summary>
-        protected virtual void SaveConfigfile(Hashtable inGameAxis, DeviceControl deviceControl)
+        protected virtual void SaveConfigfile(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl)
         {
             string filename = appReg.GetInstallDir() + "/User/Config/falcon bms.cfg";
             string fbackupname = appReg.GetInstallDir() + "/User/Config/Backup/falcon bms.cfg";
@@ -214,7 +214,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
         /// <summary>
         /// As the name inplies...
         /// </summary>
-        protected virtual void SaveKeyMapping(Hashtable inGameAxis, DeviceControl deviceControl, KeyFile keyFile)
+        protected virtual void SaveKeyMapping(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl, KeyFile keyFile)
         {
             string filename = appReg.GetInstallDir() + "/User/Config/" + appReg.getKeyFileName();
             string fbackupname = appReg.GetInstallDir() + "/User/Config/Backup/" + appReg.getKeyFileName();
@@ -232,7 +232,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
             {
                 sw.Write(deviceControl.joyAssign[i].GetKeyLineDX(i, deviceControl.devList.Count));
                 // PRIMARY DEVICE POV
-                if (((InGameAxAssgn)inGameAxis["Roll"]).GetDeviceNumber() == i) 
+                if (inGameAxis[AxisName.Roll].GetDeviceNumber() == i)
                     sw.Write(deviceControl.joyAssign[i].GetKeyLinePOV());
             }
             sw.Close();
@@ -302,7 +302,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
         /// <summary>
         /// As the name inplies...
         /// </summary>
-        protected void SaveAxisMapping(Hashtable inGameAxis, DeviceControl deviceControl)
+        protected void SaveAxisMapping(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl)
         {
             string filename = appReg.GetInstallDir() + "/User/Config/axismapping.dat";
             string fbackupname = appReg.GetInstallDir() + "/User/Config/Backup/axismapping.dat";
@@ -317,16 +317,16 @@ namespace FalconBMS_Alternative_Launcher_Cs
 
             byte[] bs;
             
-            if (((InGameAxAssgn)inGameAxis["Pitch"]).GetDeviceNumber() > -1)
+            if (inGameAxis[AxisName.Pitch].GetDeviceNumber() > -1)
             {
                 bs = new byte[] 
                 {
-                    (byte)(((InGameAxAssgn)inGameAxis["Pitch"]).GetDeviceNumber()+2),
+                    (byte)(inGameAxis[AxisName.Pitch].GetDeviceNumber()+2),
                     0x00, 0x00, 0x00
                 };
                 fs.Write(bs, 0, bs.Length);
 
-                bs = deviceControl.joyAssign[(byte)((InGameAxAssgn)inGameAxis["Pitch"]).GetDeviceNumber()]
+                bs = deviceControl.joyAssign[(byte)inGameAxis[AxisName.Pitch].GetDeviceNumber()]
                     .GetInstanceGUID().ToByteArray();
                 fs.Write(bs, 0, bs.Length);
 
@@ -348,7 +348,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
             AxisName[] localAxisMappingList = this.getAxisMappingList();
             foreach (AxisName nme in localAxisMappingList)
             {
-                if (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetDeviceNumber() == -1)
+                if (inGameAxis[nme].GetDeviceNumber() == -1)
                 {
                     bs = new byte[] 
                     {
@@ -360,27 +360,27 @@ namespace FalconBMS_Alternative_Launcher_Cs
                     fs.Write(bs, 0, bs.Length);
                     continue;
                 }
-                if (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetDeviceNumber() > -1)
+                if (inGameAxis[nme].GetDeviceNumber() > -1)
                 {
                     bs = new byte[] 
                     {
-                        (byte)(((InGameAxAssgn)inGameAxis[nme.ToString()]).GetDeviceNumber()+2),
+                        (byte)(inGameAxis[nme].GetDeviceNumber()+2),
                         0x00, 0x00, 0x00
                     };
                     fs.Write(bs, 0, bs.Length);
                     bs = new byte[] 
                     {
-                        (byte)((InGameAxAssgn)inGameAxis[nme.ToString()]).GetPhysicalNumber(),
+                        (byte)inGameAxis[nme].GetPhysicalNumber(),
                         0x00, 0x00, 0x00
                     };
                     fs.Write(bs, 0, bs.Length);
                 }
-                if (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetDeviceNumber() == -2)
+                if (inGameAxis[nme].GetDeviceNumber() == -2)
                 {
                     bs = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
                     fs.Write(bs, 0, bs.Length);
                 }
-                switch (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetDeadzone())
+                switch (inGameAxis[nme].GetDeadzone())
                 {
                     case AxCurve.None:
                         bs = new byte[] { 0x00, 0x00, 0x00, 0x00 };
@@ -396,7 +396,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
                         break;
                 }
                 fs.Write(bs, 0, bs.Length);
-                switch (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetSaturation())
+                switch (inGameAxis[nme].GetSaturation())
                 {
                     case AxCurve.None:
                         bs = new byte[] { 0xFF, 0xFF, 0xFF, 0xFF };
@@ -419,7 +419,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
         /// <summary>
         /// As the name inplies...
         /// </summary>
-        protected virtual void SaveJoystickCal(Hashtable inGameAxis, DeviceControl deviceControl)
+        protected virtual void SaveJoystickCal(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl)
         {
             string filename = appReg.GetInstallDir() + "/User/Config/joystick.cal";
             string fbackupname = appReg.GetInstallDir() + "/User/Config/Backup/joystick.cal";
@@ -444,7 +444,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00, 0x00
                 };
-                if (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetDeviceNumber() != -1)
+                if (inGameAxis[nme].GetDeviceNumber() != -1)
                 {
                     bs[12] = 0x01;
 
@@ -471,7 +471,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
                             bs[5] = 0x3A;
                     }
                 }
-                if (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetInvert())
+                if (inGameAxis[nme].GetInvert())
                 {
                     bs[20] = 0x01;
                 }
@@ -832,7 +832,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
         {
         }
 
-        protected override void SaveConfigfile(Hashtable inGameAxis, DeviceControl deviceControl)
+        protected override void SaveConfigfile(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl)
         {
             string filename = appReg.GetInstallDir() + "/User/Config/falcon bms.cfg";
             string fbackupname = appReg.GetInstallDir() + "/User/Config/Backup/falcon bms.cfg";
@@ -863,20 +863,20 @@ namespace FalconBMS_Alternative_Launcher_Cs
                 + "          // SETUP OVERRIDE\r\n");
             cfg.Write("set g_b3DClickableCursorAnchored " + Convert.ToInt32(mainWindow.Misc_MouseCursorAnchor.IsChecked)
                 + "          // SETUP OVERRIDE\r\n");
-            if (((InGameAxAssgn)inGameAxis["Roll"]).GetDeviceNumber() == ((InGameAxAssgn)inGameAxis["Throttle"]).GetDeviceNumber())
+            if (inGameAxis[AxisName.Roll].GetDeviceNumber() == inGameAxis[AxisName.Throttle].GetDeviceNumber())
             {
                 cfg.Close();
                 return;
             }
             cfg.Write("set g_nNumOfPOVs 2      // SETUP OVERRIDE\r\n");
-            cfg.Write("set g_nPOV1DeviceID " + (((InGameAxAssgn)inGameAxis["Roll"]).GetDeviceNumber() + 2).ToString() + "   // SETUP OVERRIDE\r\n");
+            cfg.Write("set g_nPOV1DeviceID " + (inGameAxis[AxisName.Roll].GetDeviceNumber() + 2).ToString() + "   // SETUP OVERRIDE\r\n");
             cfg.Write("set g_nPOV1ID 0         // SETUP OVERRIDE\r\n");
-            cfg.Write("set g_nPOV2DeviceID " + (((InGameAxAssgn)inGameAxis["Throttle"]).GetDeviceNumber() + 2).ToString() + "   // SETUP OVERRIDE\r\n");
+            cfg.Write("set g_nPOV2DeviceID " + (inGameAxis[AxisName.Throttle].GetDeviceNumber() + 2).ToString() + "   // SETUP OVERRIDE\r\n");
             cfg.Write("set g_nPOV2ID 0         // SETUP OVERRIDE\r\n");
             cfg.Close();
         }
 
-        protected override void SaveKeyMapping(Hashtable inGameAxis, DeviceControl deviceControl, KeyFile keyFile)
+        protected override void SaveKeyMapping(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl, KeyFile keyFile)
         {
             string filename = appReg.GetInstallDir() + "/User/Config/" + appReg.getKeyFileName();
             string fbackupname = appReg.GetInstallDir() + "/User/Config/Backup/" + appReg.getKeyFileName();
@@ -894,14 +894,14 @@ namespace FalconBMS_Alternative_Launcher_Cs
             {
                 sw.Write(deviceControl.joyAssign[i].GetKeyLineDX(i, deviceControl.devList.Count));
                 // PRIMARY DEVICE POV
-                if (((InGameAxAssgn)inGameAxis["Roll"]).GetDeviceNumber() == i && ((InGameAxAssgn)inGameAxis["Roll"]).GetDeviceNumber() == ((InGameAxAssgn)inGameAxis["Throttle"]).GetDeviceNumber())
+                if (inGameAxis[AxisName.Roll].GetDeviceNumber() == i && inGameAxis[AxisName.Roll].GetDeviceNumber() == inGameAxis[AxisName.Throttle].GetDeviceNumber())
                 {
                     sw.Write(deviceControl.joyAssign[i].GetKeyLinePOV());
                     continue;
                 }
-                if (((InGameAxAssgn)inGameAxis["Roll"]).GetDeviceNumber() == i)
+                if (inGameAxis[AxisName.Roll].GetDeviceNumber() == i)
                     sw.Write(deviceControl.joyAssign[i].GetKeyLinePOV(0));
-                if (((InGameAxAssgn)inGameAxis["Throttle"]).GetDeviceNumber() == i)
+                if (inGameAxis[AxisName.Throttle].GetDeviceNumber() == i)
                     sw.Write(deviceControl.joyAssign[i].GetKeyLinePOV(1));
             }
             sw.Close();
@@ -925,7 +925,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
         /// <summary>
         /// As the name inplies...
         /// </summary>
-        protected override void SaveJoystickCal(Hashtable inGameAxis, DeviceControl deviceControl)
+        protected override void SaveJoystickCal(Dictionary<AxisName, InGameAxAssgn> inGameAxis, DeviceControl deviceControl)
         {
             string filename = appReg.GetInstallDir() + "/User/Config/joystick.cal";
             string fbackupname = appReg.GetInstallDir() + "/User/Config/Backup/joystick.cal";
@@ -949,7 +949,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
                 };
-                if (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetDeviceNumber() != -1)
+                if (inGameAxis[nme].GetDeviceNumber() != -1)
                 {
                     bs[12] = 0x01;
 
@@ -976,7 +976,7 @@ namespace FalconBMS_Alternative_Launcher_Cs
                             bs[5] = 0x3A;
                     }
                 }
-                if (((InGameAxAssgn)inGameAxis[nme.ToString()]).GetInvert())
+                if (inGameAxis[nme].GetInvert())
                 {
                     bs[20] = 0x01;
                     bs[21] = 0x01;


### PR DESCRIPTION
- Make axis assignment less stringly-typed

  Don't needlessly convert to/from strings to map axis binds.
  This changes the XML format, but...

- DeviceControl: Delete files if they fail to deserialize

  This is a more graceful UX then failing: We'll load what we can from BMS
  config, then save it back out on exit.