### PR TITLE
Don't clear category dropdown after assigning control

### DIFF
--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -261,7 +261,7 @@ namespace FalconBMS.Launcher.Windows
 
                 joyAssign_2_inGameAxis();
                 ResetAssgnWindow();
-                ResetJoystickColumn();
+                RefreshJoystickColumn();
             }
             catch (Exception ex)
             {

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
@@ -38,11 +38,9 @@ namespace FalconBMS.Launcher.Windows
 
             KeyMappingGrid.ItemsSource = keyFile.keyAssign;
         }
-        public void ResetJoystickColumn()
+        public void RefreshJoystickColumn()
         {
-            var temp = KeyMappingGrid.ItemsSource;
-            KeyMappingGrid.ItemsSource = null;
-            KeyMappingGrid.ItemsSource = temp;
+            KeyMappingGrid.Items.Refresh();
 
             statusAssign = Status.GetNeutralPos;
         }


### PR DESCRIPTION
When a category is selected in the category dropdown, after binding a control the category is cleared and the list will jump to the bottom. This makes it difficult to bind a bunch of controls quickly because the list resets itself after every bind (videos have audio):

https://user-images.githubusercontent.com/123499/205466329-fe2ea58a-fd1d-4b36-b7ea-fafe74bf1364.mp4

This PR fixes it by no longer clearing the category dropdown after a control is bound:

https://user-images.githubusercontent.com/123499/205466346-c7126a4e-b79c-4a4c-9f3f-0e8580b3a776.mp4