### PR TITLE
Make minimize/maximize/close buttons more visible

### DIFF
--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         Title="FalconBMS Alternative Launcher" Height="768" Width="1024" MinHeight="768" MinWidth="1024" BorderThickness="0"
         Loaded="Window_Loaded" Closed="Window_Closed" MouseDown="MetroWindow_MouseDown"
-        FontSize="12" WindowStartupLocation="CenterScreen" ShowTitleBar="False" WindowStyle="None" Background="#a4a9ac">
+        FontSize="12" WindowStartupLocation="CenterScreen" ShowTitleBar="False" WindowStyle="None" Background="#a4a9ac" OverrideDefaultWindowCommandsBrush="#a4a9ac">
     <Window.Resources>
         <Style TargetType="Label">
             <Setter Property="Foreground" Value="#80FFFFFF" />


### PR DESCRIPTION
This PR makes the minimize/maximize/close buttons on the upper right corner of the window more visible. Previously they were black icons on a dark blue background, which were very hard to see:

![before](https://user-images.githubusercontent.com/123499/212680986-f30bfd86-3c38-4c10-abb3-811664eebdb0.png)

This PR changes them to the same gray color as the background, which makes them more visible:

![after](https://user-images.githubusercontent.com/123499/212681073-86340299-90f5-445d-8ca1-80e53b2980b4.png)
