### PR TITLE
Check for additional OpenVR paths

### DIFF
--- a/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
+++ b/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
@@ -79,6 +79,9 @@
       <HintPath>C:\windows\Microsoft.NET\DirectX for Managed Code\1.0.2902.0\Microsoft.DirectX.DirectInput.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualC" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Data" />

--- a/Falcon BMS Alternative Launcher/packages.config
+++ b/Falcon BMS Alternative Launcher/packages.config
@@ -3,4 +3,5 @@
   <package id="Autoupdater.NET.Official" version="1.7.0" targetFramework="net461" />
   <package id="ControlzEx" version="3.0.2.4" targetFramework="net461" />
   <package id="MahApps.Metro" version="1.6.5" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- in %localappdata%\OpenVR\openvrpaths.vrpath
- Windows registry location for SteamVR uninstaller

https://github.com/ValveSoftware/openvr/wiki/Local-Driver-Registration

This solves an issue I had on my machine where the SteamVR was not located in the Steam installation directory. This seems to be as close to a canonical way to find the SteamVR path as exists.

Further addresses #85 