### PR TITLE
Don't zero out 'Show Mirrors' flag when writing 'Show Pilot Model' flag.

### DIFF
--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor434.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor434.cs
@@ -127,7 +127,7 @@ namespace FalconBMS.Launcher.Override
             if (mainWindow.Misc_SmartScalingOverride.IsChecked == true)
                 bs[12] = 0x05;
 
-            // Smart Scaling
+            // Pilot Model
             bs[0] = 0x13;
             if (mainWindow.Misc_PilotModel.IsChecked == true)
                 bs[0] = 0x33;

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
@@ -113,10 +113,13 @@ namespace FalconBMS.Launcher.Override
             if (mainWindow.Misc_SmartScalingOverride.IsChecked == true)
                 bs[12] = 0x05;
 
-            // Smart Scaling
-            bs[0] = 0x13;
+            // Pilot Model -- bit #6; NB: in v4.37 and later, 'Show Mirrors' is bit #7 so don't overwrite that.
+            //TODO: consider adding separate checkbox for 'Show Mirrors'?
+			//TODO: consider AL should get out of the business of duplicating these settings, if BMS 2d UI is not dead code?
+            bs[0] &= 0b01110011; //turn off bits 3,4 and 8.. maybe necessary if older pop file is ported forward from older BMS? not sure
+            bs[0] |= 0b00010011; //turn on bits 1,2 and 5
             if (mainWindow.Misc_PilotModel.IsChecked == true)
-                bs[0] = 0x33;
+                bs[0] |= 0b00100000; //turn on bit 6
 
             fs = new FileStream
                 (filename, FileMode.Create, FileAccess.Write);


### PR DESCRIPTION
NOT TESTED .. just a quick and dirty PR for sake of discussion.

Issue => https://github.com/chihirobelmo/FalconBMS-Alternative-Launcher/issues/97

Q: Do we want to do a quick, surgical fix..   or should we reconsider whether AL should duplicate all of these "green checkbox" config options in the pop file .. smart scaling, pilot model, etc?

I don't fully understand the original rationale, for duplicating these in AL.  (It seems like the only thing AL needed to write in the pop file is the path to the key file.)

But I also don't know enough of current plan and state of 4.38 development, to have an opinion -- viz. is new work being done on the BMS 2d experience?  or is the strategy to migrate more of the UI for those various Graphics/Sound/Simulation settings (and cfg file settings) into AL?