### PR TITLE
BugFix/102 - Fixed POV keyline writeout : write all POVs for all joystick devices

### DIFF
--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
@@ -22,5 +22,19 @@ namespace FalconBMS.Launcher.Override
                 + Convert.ToInt32(mainWindow.Misc_VR.IsChecked)
                 + CommonConstants.CFGOVERRIDECOMMENT + "\r\n");
         }
+
+        protected override void WriteKeyLines(string filename, Hashtable inGameAxis, DeviceControl deviceControl, KeyFile keyFile, int DXnumber)
+        {
+            StreamWriter sw = new StreamWriter
+                (filename, false, Encoding.GetEncoding("utf-8"));
+            for (int i = 0; i < keyFile.keyAssign.Length; i++)
+                sw.Write(keyFile.keyAssign[i].GetKeyLine());
+            for (int i = 0; i < deviceControl.joyAssign.Length; i++)
+            {
+                sw.Write(deviceControl.joyAssign[i].GetKeyLineDX(i, deviceControl.joyAssign.Length, DXnumber));
+                sw.Write(deviceControl.joyAssign[i].GetKeyLinePOV());
+            }
+            sw.Close();
+        }
     }
 }


### PR DESCRIPTION
Proposed fix for issue #102 

I acknowledge that I do not fully understand or know the history behind the original implementation and why roll + throttle device is handled differently to seperate roll & throttle devices, but : 

**The changes presented here allow for multiple POVs from any same device to be used in BMS _(provided the correct g_nPOV2DeviceID & g_nPOV2ID are set)_**
