### PR TITLE
Fix for issues/106 -- actually fetch RSS async'ly and make initialization more deterministic

### DIFF
--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
         mc:Ignorable="d"
         Title="FalconBMS Alternative Launcher" Height="768" Width="1024" MinHeight="768" MinWidth="1024" BorderThickness="0"
-        Loaded="Window_Loaded" Closed="Window_Closed" MouseDown="MetroWindow_MouseDown"
+        Closed="Window_Closed" MouseDown="MetroWindow_MouseDown"
         FontSize="12" WindowStartupLocation="CenterScreen" ShowTitleBar="False" WindowStyle="None" Background="#a4a9ac" OverrideDefaultWindowCommandsBrush="#a4a9ac">
     <Window.Resources>
         <Style TargetType="Label">

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -59,7 +59,7 @@ namespace FalconBMS.Launcher.Windows
             base.OnInitialized(e);
 
             // Schedule remaining work via PostMessage to UI thread message queue, to ensure initialization is complete
-			// for our window and for all children, before proceeding.
+            // for our window and for all children, before proceeding.
             Dispatcher.BeginInvoke((Action) delegate { _Post_OnInitialized(); });
         }
 

--- a/Falcon BMS Alternative Launcher/Windows/RSSReader.cs
+++ b/Falcon BMS Alternative Launcher/Windows/RSSReader.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 using System.ServiceModel.Syndication;
 using System.Xml;
 
-using FalconBMS.Launcher.Input;
 using System.Windows.Documents;
 using System.Windows;
 using System.Windows.Media;
@@ -16,12 +13,14 @@ namespace FalconBMS.Launcher.Windows
 {
     public class RSSReader
     {
-        private static Article[] article = new Article[0];
+        static List<Article> s_articles = new List<Article>(10);
+
         public static void Read(string url)
         {
             Read(url, null);
         }
-        public static async Task Read(string url, string top)
+
+        public static void Read(string url, string top)
         {
             try
             {
@@ -30,8 +29,8 @@ namespace FalconBMS.Launcher.Windows
 
                 foreach (SyndicationItem item in feed.Items)
                 {
-                    Array.Resize(ref article, article.Length + 1);
-                    article[article.Length - 1] = new Article(item, top);
+                    Article article = new Article(item, top);
+                    s_articles.Add(article);
                 }
             }
             catch (Exception ex)
@@ -41,15 +40,21 @@ namespace FalconBMS.Launcher.Windows
             }
         }
 
-
         public static void Write(System.Windows.Controls.TextBlock textblock)
         {
+            //Self-test to assert we're running on the correct UI thread.
+            int currentThreadId = Thread.CurrentThread.ManagedThreadId;
+            int textblockThreadId = textblock.Dispatcher.Thread.ManagedThreadId;
+            System.Diagnostics.Debug.Assert(currentThreadId == textblockThreadId);
+            
             try
             {
-                article = article.OrderByDescending(a => a.dateTime).ToArray();
+                s_articles.Sort();
 
-                for (int i = 0; i < 10; i++)
-                    article[i].Write(textblock);
+                foreach (Article article in s_articles)
+                {
+                    article.Write(textblock);
+                }
             }
             catch (Exception ex)
             {
@@ -59,7 +64,7 @@ namespace FalconBMS.Launcher.Windows
             }
         }
 
-        private class Article
+        private class Article : IComparable<Article>
         {
             private string webSite;
             private string title;
@@ -124,6 +129,12 @@ namespace FalconBMS.Launcher.Windows
             private void Try_RequestNavigateTop(object sender, RequestNavigateEventArgs e)
             {
                 System.Diagnostics.Process.Start(webSite);
+            }
+
+            int IComparable<Article>.CompareTo(Article other)
+            {
+                // Default sort-order by date, descending.
+                return (-1 * DateTime.Compare(this.dateTime, other.dateTime));
             }
         }
     }


### PR DESCRIPTION
- Replace problematic async code with simple background-thread callback to fetch RSS; then post results via UI thread.
- Replace async Loaded event handler with simple OnInitialized override, to explicitly control the timing of initialization.