### PR TITLE
Post-U3 fixes

### DIFF
--- a/Falcon BMS Alternative Launcher/App.xaml.cs
+++ b/Falcon BMS Alternative Launcher/App.xaml.cs
@@ -20,7 +20,7 @@ namespace FalconBMS.Launcher
         {
             if (e.Exception is NotImplementedException)
             {
-                MessageBox.Show("This feature has not yet been implemented.", "Feature not Implemented",
+                MessageBox.Show(Program.mainWin, "This feature has not yet been implemented.", "Feature not Implemented",
                     MessageBoxButton.OK, MessageBoxImage.Information);
 
                 e.Handled = true;

--- a/Falcon BMS Alternative Launcher/AutoUpdate.xml
+++ b/Falcon BMS Alternative Launcher/AutoUpdate.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <item>
-  <version>2.1.3</version>
-  <url>https://github.com/chihirobelmo/FalconBMS-Alternative-Launcher/releases/download/v2.1.3/Falcon_BMS_Alternative_Launcher_Setup_v2.1.3.msi</url>
+  <version>2.4.1.5</version>
+  <!--<url>https://github.com/chihirobelmo/FalconBMS-Alternative-Launcher/releases/download/v2.4.1.5/FalconBMS_Alternative_Launcher_v2.4.1.5-release.zip</url>-->
+  <url>https://cdn.falcon-bits.net/FalconBMS_Alternative_Launcher_v2.4.1.5-release.zip</url>
 </item>

--- a/Falcon BMS Alternative Launcher/Diagnostics.cs
+++ b/Falcon BMS Alternative Launcher/Diagnostics.cs
@@ -67,7 +67,7 @@ namespace FalconBMS.Launcher
             if (ex != null)
                 message += "\r\n\r\n" + ex.GetType() + "\r\n" + ex.Message;
 
-            MessageBox.Show(message, "Error",
+            MessageBox.Show(Program.mainWin, message, "Error",
                 MessageBoxButton.OK, MessageBoxImage.Error);
         }
 

--- a/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
+++ b/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Diagnostics.cs" />
     <Compile Include="Input\DxAssgn.cs" />
     <Compile Include="Input\InGameAxAssgn.cs" />
+    <None Include="Input\CmdLineArgs.md" />
     <Compile Include="Input\KeyFile.cs" />
     <Compile Include="Override\OverrideSettingFor438.cs" />
     <Compile Include="Starter\Starter436I.cs" />

--- a/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
+++ b/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
@@ -62,9 +62,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoUpdater.NET, Version=1.7.0.0, Culture=neutral, PublicKeyToken=501435c91b35f4bc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autoupdater.NET.Official.1.7.0\lib\net45\AutoUpdater.NET.dll</HintPath>
-    </Reference>
     <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\ControlzEx.dll</HintPath>
     </Reference>

--- a/Falcon BMS Alternative Launcher/Input/CmdLineArgs.md
+++ b/Falcon BMS Alternative Launcher/Input/CmdLineArgs.md
@@ -1,0 +1,22 @@
+﻿Documentation notes for BMS command-line arguments:
+
+-mono
+Opens a companion console window for the "monoprint" debug output -- this log output will also be saved in .\User\Logs subdirectory.
+
+-ef
+Short for "EyeFly" -- enables the ability for absolute control of external camera positioning.  Useful for debugging, and for capturing unique angles of action.  Consult sec. TODO for more information on EyeFly.
+
+-acmi
+Automatically begins ACMI recording, when entering 3D -- mainly useful for multiplayer hosts, especially when a dedicated, non-rendering server is used.  Warning: will result in very large, long acmi recording files.  Alternatively, use the TODO callback to toggle ACMI recording on/off.  Consult sec. TODO for more information on ACMI.
+
+-nomovie
+Skips the movie during the opening splash screen sequence.  Equivalent to `set g_bPlayIntroMovie 0` config setting.
+
+-window
+Launch the 2D menu screen in borderless-window mode -- can help workaround or avoid compatibility problems launching directly into fullscreen-exclusive mode.
+
+-vr
+Launch BMS in VR mode.  See also `g_nVRHMD` config parameter.
+
+-novr
+Launch BMS in normal flatscreen (non-VR) mode.  (Overrides the `g_nVRHMD` config parameter.)

--- a/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
+++ b/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
@@ -165,14 +165,24 @@ namespace FalconBMS.Launcher.Input
             {
                 this.UpdateAvionicsProfile(null);//generic F16
 
+                XmlSerializer serializer = new XmlSerializer(typeof(JoyAssgn));
                 for (int i = 0; i < this.joyAssign.Length; i++)
                 {
                     string fileName = this.appReg.GetInstallDir() + CommonConstants.CONFIGFOLDER + CommonConstants.SETUPV100 + this.joyAssign[i].GetProductFileName()
                     + " {" + this.joyAssign[i].GetInstanceGUID().ToString().ToUpper() + "}.xml";
 
-                    XmlSerializer serializer = new XmlSerializer(typeof(JoyAssgn));
                     using (StreamWriter sw = Utils.CreateUtf8TextWihoutBom(fileName))
                         serializer.Serialize(sw, this.joyAssign[i]);
+
+                    // QUICKFIX: Save a duplicate copy in a safe space, to guard against possibility of user (accidentally or
+                    // purposefully) running an older AL against 4.37.3 or later install -- this will silently delete the
+                    // user's F-15 profile from the XML files!
+                    if (!Directory.Exists(this.appReg.GetInstallDir() + CommonConstants.BACKUPFOLDER))
+                        Directory.CreateDirectory(this.appReg.GetInstallDir() + CommonConstants.BACKUPFOLDER);
+
+                    string backupPath = this.appReg.GetInstallDir() + CommonConstants.BACKUPFOLDER + 
+                        CommonConstants.SETUPV100 + this.joyAssign[i].GetProductFileName() + " {" + this.joyAssign[i].GetInstanceGUID().ToString().ToUpper() + "}.xml";
+                    File.Copy(fileName, backupPath, overwrite: true);
                 }
             }
             catch (Exception ex)

--- a/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
+++ b/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
@@ -146,20 +146,6 @@ namespace FalconBMS.Launcher.Input
         {
             return joyAssign;
         }
-        //public JoyAssgn[] GetJoystickMappingsForProfile(string profile)
-        //{
-        //    switch (profile)
-        //    {
-        //        case null:
-        //            return joyAssign;
-        //        case CommonConstants.F15_TAG:
-        //            List<JoyAssgn> list = new List<JoyAssgn>();
-        //            foreach (JoyAssgn joy in joyAssign)
-        //                list.Add(joy);
-        //            return list.ToArray();
-        //    }
-        //    throw new System.ArgumentException("avionicsProfile");
-        //}
 
         public void UpdateAvionicsProfile(string profile)
         {

--- a/Falcon BMS Alternative Launcher/Input/DxAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/DxAssgn.cs
@@ -14,7 +14,7 @@ namespace FalconBMS.Launcher.Input
         /// [2]=RELEASE
         /// [3]=RELEASE + SHIFT
         /// </summary>
-        public Assgn[] assign = new Assgn[CommonConstants.DX_MAX_HATS];
+        public Assgn[] assign = new Assgn[4];
 
         // Constructor
         public DxAssgn()
@@ -32,6 +32,11 @@ namespace FalconBMS.Launcher.Input
         public void Assign(string callback, Pinky pinky, Behaviour behaviour, Invoke invoke, int soundID)
         {
             assign[(int)pinky + (int)behaviour] = new Assgn(callback, invoke, soundID);
+        }
+
+        public string GetCurrentCallback(Pinky pinky, Behaviour behaviour)
+        {
+            return assign[(int)pinky + (int)behaviour].GetCallback();
         }
 
         public DxAssgn Clone()

--- a/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
@@ -411,8 +411,14 @@ namespace FalconBMS.Launcher.Input
             Debug.Assert(otherJoy.dx.Length == this.dx.Length);
             Debug.Assert(otherJoy.pov.Length == this.pov.Length);
 
-            Array.Copy(otherJoy.dx, this.dx, this.dx.Length);
-            Array.Copy(otherJoy.pov, this.pov, this.pov.Length);
+            int ndx = Math.Min(this.dx.Length, otherJoy.dx.Length);
+            for (int i = 0; i < ndx; i++)
+                this.dx[i] = otherJoy.dx[i].Clone();
+
+            int npov = Math.Min(this.pov.Length, otherJoy.pov.Length);
+            for (int i = 0; i < npov; i++)
+                this.pov[i] = otherJoy.pov[i].Clone();
+
             return;
         }
 

--- a/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
@@ -427,7 +427,11 @@ namespace FalconBMS.Launcher.Input
                 this.axis = xmlJoy.axis;
                 this.detentPosition = xmlJoy.detentPosition;
 
-                // Upgrade-path: these profile* subnodes will be null, when loading an older XML file.
+                // Bugfix: Pad-up any downlevel XML files from the DX32 era (32 button-slots per device) to avoid index-out-of-bounds exceptions later.
+                // This can happen when user forward-ports an older xml file.. or, loads a Stock template that was crafted with 32 button slots.
+                xmlJoy.PatchDX32ButtonArray();
+
+                // Upgrade-path from pre-F15 (BMS 4.37.3) era: these profile* subnodes will be null, when loading an older XML file.
                 if (xmlJoy.profileDefaultF16.dx == null)
                 {
                     Debug.Assert(xmlJoy.profileDefaultF16.dx == null);
@@ -475,7 +479,6 @@ namespace FalconBMS.Launcher.Input
             _Debug_ValidateCurrentProfile();
             return;
         }
-
 
         public JoyAssgn MakeTempCloneForKeyMappingDialog()
         {
@@ -526,6 +529,29 @@ namespace FalconBMS.Launcher.Input
             {
                 return new int[8];
             }
+        }
+
+        private void PatchDX32ButtonArray()
+        {
+            if (this.dx.Length < CommonConstants.DX_MAX_BUTTONS)
+            {
+                DxAssgn[] newArray = new DxAssgn[CommonConstants.DX_MAX_BUTTONS];
+                for (int i = 0; i < CommonConstants.DX_MAX_BUTTONS; i++)
+                    newArray[i] = (i < dx.Length ? dx[i] : new DxAssgn());
+
+                this.dx = newArray;
+            }
+
+            if (this.pov.Length < CommonConstants.DX_MAX_HATS)
+            {
+                PovAssgn[] newArray = new PovAssgn[CommonConstants.DX_MAX_HATS];
+                for (int i = 0; i < CommonConstants.DX_MAX_HATS; i++)
+                    newArray[i] = (i < pov.Length ? pov[i] : new PovAssgn());
+
+                this.pov = newArray;
+            }
+
+            return;
         }
 
         private void _Debug_ValidateCurrentProfile()

--- a/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
@@ -385,7 +385,7 @@ namespace FalconBMS.Launcher.Input
             {
                 for (int ii = 0; ii < pov[i].direction.Length; ii++)
                 {
-                    string direction = pov[i].GetDirection(ii);
+                    string direction = pov[i].GetDirectionLabel(ii);
                     for (int iii = 0; iii < 2; iii++)
                     {
                         if (pov[i].direction[ii].GetCallback((Pinky)iii) == CommonConstants.SIMDONOTHING)

--- a/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
@@ -437,6 +437,15 @@ namespace FalconBMS.Launcher.Input
                 // This can happen when user forward-ports an older xml file.. or, loads a Stock template that was crafted with 32 button slots.
                 xmlJoy.PatchDX32ButtonArray();
 
+                // Bugfix: Due to the bug above, some beta-testers are left with XML files in a borken state.. discard the profile nodes.
+                if (xmlJoy.profileDefaultF16.dx != null && xmlJoy.profileDefaultF16.dx.Length < CommonConstants.DX_MAX_BUTTONS)
+                {
+                    xmlJoy.profileDefaultF16.dx = null;
+                    xmlJoy.profileDefaultF16.pov = null;
+                    xmlJoy.profileF15ABCD.dx = null;
+                    xmlJoy.profileF15ABCD.pov = null;
+                }
+
                 // Upgrade-path from pre-F15 (BMS 4.37.3) era: these profile* subnodes will be null, when loading an older XML file.
                 if (xmlJoy.profileDefaultF16.dx == null)
                 {
@@ -517,7 +526,12 @@ namespace FalconBMS.Launcher.Input
         {
             try
             {
-                return hwDevice.CurrentJoystickState.GetButtons();
+                byte[] buttonStates = hwDevice.CurrentJoystickState.GetButtons();
+                if (buttonStates.Length == CommonConstants.DX_MAX_BUTTONS) return buttonStates;
+
+                byte[] buttonStates128 = new byte[CommonConstants.DX_MAX_BUTTONS];
+                Array.Copy(buttonStates, buttonStates128, Math.Min(buttonStates.Length, buttonStates128.Length));
+                return buttonStates128;
             }
             catch 
             {
@@ -529,7 +543,12 @@ namespace FalconBMS.Launcher.Input
         {
             try
             {
-                return hwDevice.CurrentJoystickState.GetPointOfView();
+                int[] hatStates = hwDevice.CurrentJoystickState.GetPointOfView();
+                if (hatStates.Length == CommonConstants.DX_MAX_HATS) return hatStates;
+
+                int[] hatStates8 = new int[CommonConstants.DX_MAX_HATS];
+                Array.Copy(hatStates, hatStates8, Math.Min(hatStates.Length, hatStates8.Length));
+                return hatStates8;
             }
             catch
             {

--- a/Falcon BMS Alternative Launcher/Input/KeyAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/KeyAssgn.cs
@@ -18,13 +18,15 @@ namespace FalconBMS.Launcher.Input
         protected string visibility = "-0";                    // 8th: 1=Visible -1=Headline -0=Locked -2=hidden
         protected string description = "!Alt Launcher ERROR!"; // 9th: The description
 
+        protected int numericScancode;
+        protected int numericModFlags;
+
         // for Datagrid Display //
         public string Visibility { get; set; }
         public string Mapping => " " + description.Replace("\"","");
 
         public string Key {
             get => GetKeyAssignmentStatus();
-            set => keyboard = value;
         }
 
         public string GetCallback() { return callback; }
@@ -32,6 +34,9 @@ namespace FalconBMS.Launcher.Input
         public string GetKeycomboMod() { return keycomboMod; }
         public string GetKeyDescription() { return description; }
         public int GetSoundID() { return Int32.Parse(soundID); }
+
+        public int GetScancode() { return numericScancode; }
+        public int GetModFlags() { return numericModFlags; }
 
         public KeyAssgn() { }
 
@@ -41,7 +46,9 @@ namespace FalconBMS.Launcher.Input
             soundID = stringParams[1];
             none = stringParams[2];
             keyboard = stringParams[3];
+            numericScancode = Convert.ToInt32(keyboard, fromBase:16);
             modifier = stringParams[4];
+            numericModFlags = Convert.ToInt32(modifier, fromBase:10);
             keycombo = stringParams[5];
             keycomboMod = stringParams[6];
             visibility = stringParams[7];
@@ -70,13 +77,15 @@ namespace FalconBMS.Launcher.Input
                 visibility = "White";
         }
 
-        public void getOtherKeyInstance(KeyAssgn otherInstance)
+        public void CopyOtherKeyAssgn(KeyAssgn otherInstance)
         {
             callback    = otherInstance.callback;
             soundID     = otherInstance.soundID;
             none        = otherInstance.none;
             keyboard    = otherInstance.keyboard;
+            numericScancode = otherInstance.numericScancode;
             modifier    = otherInstance.modifier;
+            numericModFlags = otherInstance.numericModFlags;
             keycombo    = otherInstance.keycombo;
             keycomboMod = otherInstance.keycomboMod;
             visibility  = otherInstance.visibility;
@@ -145,6 +154,9 @@ namespace FalconBMS.Launcher.Input
             modifier = code.ToString();
 
             keyboard = "0x" + scancode10.ToString("X");
+
+            numericScancode = scancode10;
+            numericModFlags = code;
         }
 
         /// <summary>
@@ -180,6 +192,9 @@ namespace FalconBMS.Launcher.Input
             modifier = "0";
             keycombo = "0";
             keycomboMod = "0";
+
+            numericScancode = 0;
+            numericModFlags = 0;
         }
 
         /// <summary>
@@ -221,8 +236,7 @@ namespace FalconBMS.Launcher.Input
                         break;
                 }
 
-                string scancodestr = keycombo.Remove(0, 2);
-                int scancode10 = Convert.ToInt32(scancodestr, 16);
+                int scancode10 = Convert.ToInt32(keycombo, fromBase:16);
 
                 // int -> enum
                 Key int2enum = (Key)scancode10;
@@ -261,8 +275,7 @@ namespace FalconBMS.Launcher.Input
                         break;
                 }
 
-                string scancodestr = keyboard.Replace("0x","");
-                int scancode10 = Convert.ToInt32(scancodestr, 16);
+                int scancode10 = Convert.ToInt32(keyboard, fromBase:16);
 
                 // int -> enum
                 Key int2enum = (Key)scancode10;

--- a/Falcon BMS Alternative Launcher/Input/KeyFile.cs
+++ b/Falcon BMS Alternative Launcher/Input/KeyFile.cs
@@ -25,6 +25,8 @@ namespace FalconBMS.Launcher.Input
                 return;
             }
 
+            ValidateKeyfileLines(filename);
+
             // Build table of { callbackName, keyBinding, descriptionString }.  Also build up list of category-header labels.
             List<KeyAssgn> records = new List<KeyAssgn>(2000);
 
@@ -51,8 +53,15 @@ namespace FalconBMS.Launcher.Input
                         cats.Add(ParseCategoryHeaderLabel(line)); //nb: also fall-through to add it to KeyAssgn
 
                     // Parse the key-binding line.
-                    KeyAssgn keyAssgn = ParseKeyfileLine(line);
-                    records.Add(keyAssgn);
+                    if (RegexFactory.KeyBindingLine.IsMatch(line))
+                    {
+                        KeyAssgn keyAssgn = ParseKeyfileLine(line);
+                        records.Add(keyAssgn);
+                    }
+                    else
+                    {
+                        Diagnostics.Log("Skipping malformed keyfile line: " + line, Diagnostics.LogLevels.Warning);
+                    }
                 }
             }
 

--- a/Falcon BMS Alternative Launcher/Input/KeyFile.cs
+++ b/Falcon BMS Alternative Launcher/Input/KeyFile.cs
@@ -131,6 +131,24 @@ namespace FalconBMS.Launcher.Input
             );
         }
 
+        public KeyAssgn LookupCallback(string callbackName)
+        {
+            foreach (KeyAssgn ka in this.keyAssign)
+                if (ka.GetCallback() == callbackName) return ka;
+            return null;
+        }
+
+        public KeyAssgn ReverseLookupKeyboardInput(int catchedScanCode, bool shift, bool ctrl, bool alt)
+        {
+            int modflags = 0 + ( shift ? 1 : 0 ) + ( ctrl ? 2 : 0 ) + ( alt ? 4 : 0 );
+
+            foreach (KeyAssgn ka in this.keyAssign)
+                if (ka.GetScancode() == catchedScanCode && ka.GetModFlags() == modflags && ka.GetKeycombo() == "0")
+                    return ka;
+
+            return null;
+        }
+
         public KeyFile(IReadOnlyList<KeyAssgn> keyAssign)
         {
             this.keyAssign = new KeyAssgn[keyAssign.Count];

--- a/Falcon BMS Alternative Launcher/Input/PovAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/PovAssgn.cs
@@ -23,19 +23,26 @@
         }
 
         // Method
-        public void Assign(int GetPointofView, string callback, Pinky pinky, int soundID)
+        public void Assign(int povDir, string callback, Pinky pinky, int soundID)
         {
-            if (GetPointofView > 7)
-                GetPointofView /= 4500;
-            direction[GetPointofView].Assign(callback, pinky, soundID);
+            if (povDir > 7)
+                povDir /= 4500;
+            direction[povDir].Assign(callback, pinky, soundID);
         }
 
-        public string GetDirection(int GetPointOfView)
+        public string GetCurrentCallback(int povDir, Pinky pinky)
+        {
+            if (povDir > 7)
+                povDir /= 4500;
+            return this.direction[povDir].GetCallback(pinky);
+        }
+
+        public string GetDirectionLabel(int povDir)
         {
             string direction = "";
-            if (GetPointOfView > 7)
-                GetPointOfView /= 4500;
-            switch (GetPointOfView)
+            if (povDir > 7)
+                povDir /= 4500;
+            switch (povDir)
             {
                 case 0:
                     direction = "UP";

--- a/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
@@ -445,6 +445,7 @@ namespace FalconBMS.Launcher.Override
 
         protected virtual void SetJoyCalDefaultByte(ref byte[] bs)
         {
+            //NB: this is overridden to return 24 bytes, in OverrideSettingsFor435 and later.
             bs = new byte[]
             {
                 0x00, 0x00, 0x00, 0x00, 0x98, 0x3A, 0x00, 0x00,
@@ -456,6 +457,7 @@ namespace FalconBMS.Launcher.Override
 
         protected virtual void SetJoyCalInvertByte(ref byte[] bs)
         {
+            //NB: this is overridden to write byte offset [21], in OverrideSettingsFor435 and later.
             bs[20] = 0x01;
         }
 

--- a/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
@@ -211,6 +211,21 @@ namespace FalconBMS.Launcher.Override
             {
                 deviceControl.UpdateAvionicsProfile(temp);
             }
+
+            // QUICKFIX: Save a duplicate copy in a safe space, to guard against possibility of user (accidentally or
+            // purposefully) running an older AL against 4.37.3 or later install.
+            if (!Directory.Exists(this.appReg.GetInstallDir() + CommonConstants.BACKUPFOLDER))
+                Directory.CreateDirectory(this.appReg.GetInstallDir() + CommonConstants.BACKUPFOLDER);
+
+            string backupPath = this.appReg.GetInstallDir() + CommonConstants.BACKUPFOLDER +
+                CommonConstants.BMS_AUTO + ".key";
+            File.Copy(filename, backupPath, overwrite: true);
+
+            string backupPathF15 = this.appReg.GetInstallDir() + CommonConstants.BACKUPFOLDER +
+                CommonConstants.BMS_AUTO + "-F15ABCD.key";
+            File.Copy(filenameF15, backupPathF15, overwrite: true);
+
+            return;
         }
 
         protected virtual void WriteKeyLines(string filename, Hashtable inGameAxis, KeyFile keyFile, JoyAssgn[] joyAssgns)

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
@@ -116,7 +116,9 @@ namespace FalconBMS.Launcher.Override
             // Pilot Model
             bs[0] = 0x13;
             if (mainWindow.Misc_PilotModel.IsChecked == true)
-                bs[0] |= 0b00100000; //turn on bit 6
+                bs[0] |= 0b00100000; //mask-on bit 6
+            else
+                bs[0] &= 0b11011111; //mask-off bit 6
 
             fs = new FileStream
                 (filename, FileMode.Create, FileAccess.Write);

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
@@ -120,7 +120,9 @@ namespace FalconBMS.Launcher.Override
             bs[0] &= 0b01110011; //turn off bits 3,4 and 8.. maybe necessary if older pop file is ported forward from older BMS? not sure
             bs[0] |= 0b00010011; //turn on bits 1,2 and 5
             if (mainWindow.Misc_PilotModel.IsChecked == true)
-                bs[0] |= 0b00100000; //turn on bit 6
+                bs[0] |= 0b00100000; //mask-on bit 6
+            else
+                bs[0] &= 0b11011111; //mask-off bit 6
 
             fs = new FileStream
                 (filename, FileMode.Create, FileAccess.Write);

--- a/Falcon BMS Alternative Launcher/Program.cs
+++ b/Falcon BMS Alternative Launcher/Program.cs
@@ -7,14 +7,15 @@ using System.Windows;
 using System.Windows.Threading;
 
 using System.Runtime.InteropServices;
+using FalconBMS.Launcher.Windows;
 
 namespace FalconBMS.Launcher
 {
     public class Program
     {
-        /// <summary>
-        ///     Main
-        /// </summary>
+        internal static string thisExeDir = null;
+        internal static MainWindow mainWin = null;
+
         [STAThread]
         public static void Main()
         {
@@ -22,7 +23,8 @@ namespace FalconBMS.Launcher
             {
                 // Set cwd to the EXE location.
                 string thisExe = Assembly.GetExecutingAssembly().Location;
-                string thisExeDir = Path.GetDirectoryName(thisExe);
+                thisExeDir = Path.GetDirectoryName(thisExe);
+
                 Environment.CurrentDirectory = thisExeDir;
 
                 // Launch the WPF app.

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -50,5 +50,5 @@ using System.Windows;
 // 既定値にすることができます:
 //[assembly: AssemblyVersion("2023.10.19.3")]
 //[assembly: AssemblyFileVersion("2023.10.19.3")]
-[assembly: AssemblyVersion("2.4.0.6")]
-[assembly: AssemblyFileVersion("2.4.0.6")]
+[assembly: AssemblyVersion("2.4.0.7")]
+[assembly: AssemblyFileVersion("2.4.0.7")]

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
-[assembly: AssemblyVersion("2.4.1.2")]
-[assembly: AssemblyFileVersion("2.4.1.2")]
+[assembly: AssemblyVersion("2.4.1.3")]
+[assembly: AssemblyFileVersion("2.4.1.3")]

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
-[assembly: AssemblyVersion("2.4.1.1")]
-[assembly: AssemblyFileVersion("2.4.1.1")]
+[assembly: AssemblyVersion("2.4.1.2")]
+[assembly: AssemblyFileVersion("2.4.1.2")]

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -48,7 +48,5 @@ using System.Windows;
 //
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
-//[assembly: AssemblyVersion("2023.10.19.3")]
-//[assembly: AssemblyFileVersion("2023.10.19.3")]
-[assembly: AssemblyVersion("2.4.0.7")]
-[assembly: AssemblyFileVersion("2.4.0.7")]
+[assembly: AssemblyVersion("2.4.1.1")]
+[assembly: AssemblyFileVersion("2.4.1.1")]

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
-[assembly: AssemblyVersion("2.4.1.4")]
-[assembly: AssemblyFileVersion("2.4.1.4")]
+[assembly: AssemblyVersion("2.4.1.5")]
+[assembly: AssemblyFileVersion("2.4.1.5")]

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
-[assembly: AssemblyVersion("2.4.1.3")]
-[assembly: AssemblyFileVersion("2.4.1.3")]
+[assembly: AssemblyVersion("2.4.1.4")]
+[assembly: AssemblyFileVersion("2.4.1.4")]

--- a/Falcon BMS Alternative Launcher/Starter/Starter432.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter432.cs
@@ -30,7 +30,7 @@ namespace FalconBMS.Launcher.Starter
             {
                 case "Launch_UPD":
                     process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
-                    mainWindow.minimizeWindowUntilProcessEnds(process);
+                    mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();

--- a/Falcon BMS Alternative Launcher/Starter/Starter433.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter433.cs
@@ -30,7 +30,7 @@ namespace FalconBMS.Launcher.Starter
             {
                 case "Launch_UPD":
                     process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
-                    mainWindow.minimizeWindowUntilProcessEnds(process);
+                    mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();

--- a/Falcon BMS Alternative Launcher/Starter/Starter434.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter434.cs
@@ -30,7 +30,7 @@ namespace FalconBMS.Launcher.Starter
             {
                 case "Launch_UPD":
                     process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
-                    mainWindow.minimizeWindowUntilProcessEnds(process);
+                    mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();

--- a/Falcon BMS Alternative Launcher/Starter/Starter435.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter435.cs
@@ -30,7 +30,7 @@ namespace FalconBMS.Launcher.Starter
             {
                 case "Launch_UPD":
                     process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
-                    mainWindow.minimizeWindowUntilProcessEnds(process);
+                    mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();

--- a/Falcon BMS Alternative Launcher/Starter/Starter435.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter435.cs
@@ -39,7 +39,7 @@ namespace FalconBMS.Launcher.Starter
                     mainWindow.executeOverride();
 
                     string testPlatform = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS Test.exe";
-                    if (File.Exists(testPlatform) && MessageBox.Show("Start Test Exe?", "Launcher", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                    if (File.Exists(testPlatform) && MessageBox.Show(Program.mainWin, "Start Test Exe?", "Launcher", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                     {
                         process = System.Diagnostics.Process.Start(testPlatform, strCmdText);
                         MainWindow.bmsHasBeenLaunched = true;

--- a/Falcon BMS Alternative Launcher/Starter/Starter436I.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter436I.cs
@@ -30,7 +30,7 @@ namespace FalconBMS.Launcher.Starter
             {
                 case "Launch_UPD":
                     process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
-                    mainWindow.minimizeWindowUntilProcessEnds(process);
+                    mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();

--- a/Falcon BMS Alternative Launcher/SteamVR.cs
+++ b/Falcon BMS Alternative Launcher/SteamVR.cs
@@ -19,16 +19,13 @@ namespace FalconBMS.Launcher
         public SteamVR()
         {
             string regName = "SOFTWARE\\WOW6432Node\\Valve\\Steam";
-            RegistryKey regkey = Registry.LocalMachine.OpenSubKey(regName, false);
-            if (regkey == null)
-            {
+            RegistryKey rk = Registry.LocalMachine.OpenSubKey(regName, writable:false);
+            if (rk == null)
                 return;
-            }
-            installPath = (string)regkey.GetValue("InstallPath");
-            if (installPath == null)
-            {
+
+            installPath = (string)rk.GetValue("InstallPath");
+            if (String.IsNullOrEmpty(installPath))
                 return;
-            }
 
             string vrstartpath = installPath + "\\steamapps\\common\\SteamVR\\bin\\win64\\vrstartup.exe";
 
@@ -39,7 +36,7 @@ namespace FalconBMS.Launcher
             // https://github.com/ValveSoftware/openvr/wiki/Local-Driver-Registration
             if (HasSteamVR == false)
             {
-                RegistryKey steamVRUninstallKey = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App 250820", false);
+                RegistryKey steamVRUninstallKey = Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App 250820", writable:false);
                 if (steamVRUninstallKey != null)
                 {
                     string regUninstallLocation = (string)steamVRUninstallKey.GetValue("InstallLocation");
@@ -80,7 +77,7 @@ namespace FalconBMS.Launcher
                 installPath = vrstartpath;
             }
 
-            regkey.Close();
+            rk.Close();
         }
 
         private class OpenVRJson

--- a/Falcon BMS Alternative Launcher/SteamVR.cs
+++ b/Falcon BMS Alternative Launcher/SteamVR.cs
@@ -115,7 +115,8 @@ namespace FalconBMS.Launcher
         }
         public void Stop()
         {
-            process.Close();
+            if (process != null)
+                process.Close();
         }
     }
 }

--- a/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml.cs
@@ -435,6 +435,11 @@ namespace FalconBMS.Launcher.Windows
             }
             AxisDetectionTimer.Stop();
             sw.Stop();
+
+            // Save the XML and Key files, after each change user makes.
+            MainWindow.deviceControl.SaveXml();
+            Program.mainWin.appReg.getOverrideWriter().SaveKeyMapping(MainWindow.inGameAxis, MainWindow.deviceControl);
+
             Close();
         }
 

--- a/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml.cs
@@ -347,24 +347,25 @@ namespace FalconBMS.Launcher.Windows
 
             try
             {
-                if (sw.ElapsedMilliseconds > CommonConstants.FLUSHTIME2)
-                {
-                    Microsoft.DirectX.DirectInput.DeviceList devList =
-                    Microsoft.DirectX.DirectInput.Manager.GetDevices(
-                    Microsoft.DirectX.DirectInput.DeviceClass.GameControl,
-                    Microsoft.DirectX.DirectInput.EnumDevicesFlags.AttachedOnly
-                    );
+                //REVIEW: data-loss when device list changes
+                //if (sw.ElapsedMilliseconds > CommonConstants.FLUSHTIME2)
+                //{
+                //    Microsoft.DirectX.DirectInput.DeviceList devList =
+                //    Microsoft.DirectX.DirectInput.Manager.GetDevices(
+                //    Microsoft.DirectX.DirectInput.DeviceClass.GameControl,
+                //    Microsoft.DirectX.DirectInput.EnumDevicesFlags.AttachedOnly
+                //    );
 
-                    if (devList.Count != MainWindow.deviceControl.GetJoystickMappingsForAxes().Length)
-                    {
-                        mainWindow.ReloadDevicesAndXmlMappings();
-                        Reset();
-                        mainWindow.UpdateAxisStatus();
-                    }
+                //    if (devList.Count != MainWindow.deviceControl.GetJoystickMappingsForAxes().Length)
+                //    {
+                //        mainWindow.ReloadDevicesAndXmlMappings();
+                //        Reset();
+                //        mainWindow.UpdateAxisStatus();
+                //    }
 
-                    sw.Reset();
-                    sw.Start();
-                }
+                //    sw.Reset();
+                //    sw.Start();
+                //}
 
                 switch (status)
                 {

--- a/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml.cs
@@ -17,6 +17,8 @@ namespace FalconBMS.Launcher.Windows
         {
             InitializeComponent();
 
+            this.Owner = mainWindow;
+
             this.mainWindow = mainWindow;
             this.axisAssign = axisAssign;
 
@@ -435,10 +437,6 @@ namespace FalconBMS.Launcher.Windows
             }
             AxisDetectionTimer.Stop();
             sw.Stop();
-
-            // Save the XML and Key files, after each change user makes.
-            MainWindow.deviceControl.SaveXml();
-            Program.mainWin.appReg.getOverrideWriter().SaveKeyMapping(MainWindow.inGameAxis, MainWindow.deviceControl);
 
             Close();
         }

--- a/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
@@ -119,6 +119,11 @@ namespace FalconBMS.Launcher.Windows
             string lbkPath = System.IO.Path.Combine(configFolder, pilotCallsign + ".lbk");
             string lbkPathDQ = $"{dq}{lbkPath}{dq}";
 
+            // Bugfix: don't overwrite existing lbk! This situation can happen for variety of reasons.. after changing
+            // current pilot callsign in-game.. or after a fresh reinstall, and copying over Callsign.pop, ini and lbk
+            if (File.Exists(lbkPath))
+                return;
+
             string command = $"-o {lbkPathDQ} write-default --name {pilotNameDQ} --callsign {pilotCallsignDQ}";
             //string command = 
             //    "-o \"" 

--- a/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
@@ -37,13 +37,6 @@ namespace FalconBMS.Launcher.Windows
     /// </summary>
     public partial class CallsignWindow
     {
-        //TODO: remove dead code?
-        //[DllImport("Falcon BMS Logbook Generator x86.dll", EntryPoint = "CreateLbk", CallingConvention = CallingConvention.Cdecl)]
-        //public static extern void CreateLbk_32(string fname, string callsign, string pilotname, string date);
-
-        //[DllImport("Falcon BMS Logbook Generator x64.dll", EntryPoint = "CreateLbk", CallingConvention = CallingConvention.Cdecl)]
-        //public static extern void CreateLbk_64(string fname, string callsign, string pilotname, string date);
-
         private AppRegInfo appReg;
         public CallsignWindow(AppRegInfo appReg)
         {
@@ -51,12 +44,11 @@ namespace FalconBMS.Launcher.Windows
             InitializeComponent();
         }
 
-        public static bool ShowCallsignWindow(AppRegInfo appReg)
+        public static void ShowCallsignWindow(AppRegInfo appReg)
         {
             CallsignWindow ownWindow = new CallsignWindow(appReg);
             ownWindow.ShowDialog();
-            return ownWindow.TextBox_Callsign.Text == CommonConstants.DEFAULTCALLSIGN || 
-                   ownWindow.TextBox_PilotName.Text == CommonConstants.DEFAULTPILOTNAME;
+            return;
         }
 
         private void Callsign_Changed(object sender, TextChangedEventArgs e)

--- a/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
@@ -122,7 +122,11 @@ namespace FalconBMS.Launcher.Windows
             // Bugfix: don't overwrite existing lbk! This situation can happen for variety of reasons.. after changing
             // current pilot callsign in-game.. or after a fresh reinstall, and copying over Callsign.pop, ini and lbk
             if (File.Exists(lbkPath))
+            {
+                Diagnostics.Log("Logbook file already exists - avoiding overwrite!", Diagnostics.LogLevels.Warning);
+                Close();
                 return;
+            }
 
             string command = $"-o {lbkPathDQ} write-default --name {pilotNameDQ} --callsign {pilotCallsignDQ}";
             //string command = 

--- a/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml
@@ -48,7 +48,8 @@
         <ToggleButton x:Name="Select_DX_Release" Content="RELEASE" HorizontalAlignment="Right" Margin="0,144,320,0" VerticalAlignment="Top" Width="160" Height="27" Visibility="Hidden"/>
         <Button x:Name="Select_Invoke" Content="Invoke Both" HorizontalAlignment="Right" Margin="0,176,320,0" VerticalAlignment="Top" Width="160" Click="Select_Invoke_Click" Height="27" Visibility="Hidden"/>
         <Button x:Name="Save" Content="Save" HorizontalAlignment="Left" Margin="404,176,0,0" VerticalAlignment="Top" Width="75" Click="Save_Click"/>
-        <TextBlock TextWrapping="Wrap" Margin="32,46,33,174" FontSize="10"><Run Text="* "/><Run Text="Alternative Launcher recognizes POV switch on the device whose axis is bound to Roll"/><Run Text=" or Throttle"/><Run Text="."/></TextBlock>
+        <TextBlock TextWrapping="Wrap" Margin="32,46,33,174" FontSize="9"><Run Text="* Alternative Launcher only saves POV hat bindings for the Roll and/or Throttle devices"/></TextBlock>
+        <TextBlock x:Name="CurrentlyMapped" Width="200" Height="45" TextWrapping="WrapWithOverflow" Margin="197,126,113,65" FontSize="10" FontWeight="Bold" Foreground="DarkRed"><Run Text="Input currently bound to Xxxxx"/></TextBlock>
         <Button x:Name="Select_Press" Content="PRESS" HorizontalAlignment="Right" Margin="0,144,320,0" VerticalAlignment="Top" Width="160" Click="Select_Press_Click" Height="27"/>
         <TextBlock TextWrapping="Wrap" Margin="32,176,113,10" FontSize="9"><Run Text="* "/><Run Text="Press and hold "/><Run Text="DX button wh"/><Run Text="ich"/><Run Text=" you"/><Run Text=" have"/><Run Text=" assigned to &quot;"/><Run Text="STICK:PINKY SWITCH (DXSHIFT)"/><Run Text="&quot;"/><LineBreak/><Run Text="will"/><Run Text=" lit up &quot;DX SHIFT&quot; button above."/><Run Text=" "/><Run Text=" "/><Run Text="While the button is lit up, pressing another DX button"/><LineBreak/><Run Text="will assign it to a shifted layer."/></TextBlock>
     </Grid>

--- a/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml.cs
@@ -468,7 +468,9 @@ namespace FalconBMS.Launcher.Windows
                 oldKey.UnassignKeyboard();
             }
 
-            //TODO: consider saving the XML and Key files, every time, at this point? (also AxisAssignWindow.Save)  no dirty-bit needed!
+            // Save the XML and Key files, after each change user makes.
+            deviceControlRef.SaveXml();
+            Program.mainWin.appReg.getOverrideWriter().SaveKeyMapping(MainWindow.inGameAxis, deviceControlRef);
 
             Close();
         }

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -269,7 +269,7 @@
                         <Label x:Name="Label_Platform" Content="Platform :" HorizontalAlignment="Left" Margin="0,64,0,0" VerticalAlignment="Top" FontWeight="Bold" RenderTransformOrigin="0.672,0.628" />
 
                         <Label x:Name="Label_VR" Content="Virtual Reality:" HorizontalAlignment="Left" Margin="0,64,0,0" VerticalAlignment="Top" FontWeight="Bold" />
-                        <Controls:ToggleSwitch x:Name="Misc_VR" OnLabel="Enable" OffLabel="Disable" HorizontalAlignment="Left" Margin="179,60,0,0" VerticalAlignment="Top" Background="#80FFFFFF" FontSize="12" Click="Misc_VR_Click"/>
+                        <Controls:ToggleSwitch x:Name="Misc_VR" OnLabel="Enabled" OffLabel="Disabled" HorizontalAlignment="Left" Margin="179,60,0,0" VerticalAlignment="Top" Background="#80FFFFFF" FontSize="12" Click="Misc_VR_Click"/>
                         <Label Content="Documentation and Manuals :" HorizontalAlignment="Left" Margin="0,32,0,0" VerticalAlignment="Top" FontWeight="Bold" />
                         <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
 

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -554,19 +554,6 @@
                     </ComboBox>
                     <Label Content="Category:" HorizontalAlignment="Left" Margin="223,-43,0,0" VerticalAlignment="Top" Height="26" Width="64" HorizontalContentAlignment="Right" Foreground="White"/>
                     <ComboBox x:Name="Category" ItemsSource="{Binding}" HorizontalAlignment="Left" Margin="300,-41,0,0" VerticalAlignment="Top" Width="256" BorderBrush="Black" Background="#80F0F0F0" Foreground="#FF191919" SelectionChanged="Category_SelectionChanged" Height="26" Grid.ColumnSpan="2">
-                        <!--<TextBlock Text=" TOP" FontWeight="Bold" Foreground="#FF000000"/>
-                        <TextBlock Text=" UI &amp; 3RD PARTY SOFTWARE" Foreground="#FF00C001"/>
-                        <TextBlock Text=" LEFT CONSOLE" Foreground="#FF000000"/>
-                        <TextBlock Text=" HOTAS: THROTTLE" Foreground="#FF40C0F0"/>
-                        <TextBlock Text=" LEFT AUX CONSOLE" Foreground="#FF000000"/>
-                        <TextBlock Text=" CENTER CONSOLE" Foreground="#FF000000"/>
-                        <TextBlock Text=" MFD: LEFT" Foreground="#FF40C0F0"/>
-                        <TextBlock Text=" MFD: RIGHT" Foreground="#FF40C0F0"/>
-                        <TextBlock Text=" RIGHT CONSOLE" Foreground="#FF000000"/>
-                        <TextBlock Text=" HOTAS: STICK" Foreground="#FF40C0F0"/>
-                        <TextBlock Text=" MISCELLANEOUS" Foreground="#FF000000"/>
-                        <TextBlock Text=" VIEWS" Foreground="#FF000000"/>
-                        <TextBlock Text=" RADIO COMMS" Foreground="#FF000000"/>-->
                     </ComboBox>
                     <DataGrid x:Name="KeyMappingGrid" HorizontalAlignment="Stretch" Height="auto" Margin="10,10,9.666,64.334" 
                               EnableColumnVirtualization="True" EnableRowVirtualization="True" VirtualizingPanel.IsVirtualizingWhenGrouping="True"
@@ -594,7 +581,7 @@
 
                     <ToggleButton x:Name="Select_PinkyShift" Visibility="Hidden" Content="KEYCOMBO / PINKYSHIFT" HorizontalAlignment="Right" Margin="0,12,252.666,0" VerticalAlignment="Top" Width="160" Height="27" Click="Select_PinkyShift_Click" Grid.Column="1"/>
                     <ToggleButton x:Name="Select_DX_Release" Visibility="Hidden" Content="RELEASE" HorizontalAlignment="Right" Margin="0,12,163.666,0" VerticalAlignment="Top" Width="64" Height="27" Grid.Column="1"/>
-                    <Button x:Name="ImportButton" Content="Import Key File..." Margin="285,612,268,18" Width="129" Click="ImportKeyfile_Click" Height="27" Grid.Column="1"/>
+                    <Button x:Name="ImportButton" Content="Import Key File..." HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="129" Click="ImportKeyfile_Click" Height="27" Grid.Column="1"/>
 
                     <Label Content="Filter:" HorizontalAlignment="Left" Margin="227.167,-43,0,0" VerticalAlignment="Top" Width="43" HorizontalContentAlignment="Right" Foreground="White" Grid.Column="1"/>
                     <TextBox x:Name="SearchBox" HorizontalAlignment="Left" Height="23" Margin="282.167,-41,0,0" VerticalAlignment="Top" Width="384" Background="#80F0F0F0" Foreground="#FF191919" Controls:TextBoxHelper.ClearTextButton="True" TextChanged="SearchBox_TextChanged" Grid.Column="1"/>
@@ -602,15 +589,10 @@
                     <Label Content="* Double Click a cell to Assign keys." HorizontalContentAlignment="Right" HorizontalAlignment="Right" Margin="0,0,9.666,30.334" VerticalAlignment="Bottom" Width="596" Height="29" Grid.Column="1"/>
                 </Grid>
             </TabItem>
-            <TextBox Height="23" TextWrapping="Wrap" Text="TextBox" Width="120"/>
         </TabControl>
         <Image x:Name="LOGO000" HorizontalAlignment="Left" VerticalAlignment="Top" Height="49" Source="/Resources/web_banner.png" Stretch="Uniform" Width="363" Margin="24,10,0,0"/>
         <Label x:Name="Version_Number" Content="4.37" HorizontalAlignment="Left" Margin="392,0,0,0" VerticalAlignment="Top" Foreground="#FFC4C4C4" FontSize="36"/>
         <Label x:Name="AL_Version_Number" Content="FalconBMS Launcher vX.X.X" HorizontalContentAlignment="Right" HorizontalAlignment="Right" VerticalAlignment="Bottom" FontWeight="Bold" Margin="0,0,10.333,0.334" Grid.Row="1"/>
-
-        <Button x:Name="Button_Apply_YAME64" Visibility="Hidden" Content="Apply" HorizontalAlignment="Right" Margin="0,31,10.333,0" VerticalAlignment="top" Width="128" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Click="Apply_YAME64"/>
-
-
 
     </Grid>
 </Controls:MetroWindow>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -76,7 +76,7 @@ namespace FalconBMS.Launcher.Windows
                 
                 Diagnostics.Log("AutoUpdate-check initiated.");
 
-                string BMS_Launcher_version = "FalconBMS Launcher v" + ver.Major + "." + ver.Minor + "." + ver.Build;
+                string BMS_Launcher_version = "FalconBMS Launcher v" + ver.Major + "." + ver.Minor + "." + ver.Build + "." + ver.Revision;
                 AL_Version_Number.Content = BMS_Launcher_version;
 
                 Diagnostics.Log(BMS_Launcher_version);

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -336,18 +336,18 @@ namespace FalconBMS.Launcher.Windows
                 // Save UI Properties(Like Button Status).
                 appProperties.SaveUISetup();
 
-                // Save axes, buttons and hats, and key mapping.
-                if (deviceControl == null)
-                    return;
+                //// Save axes, buttons and hats, and key mapping.
+                //if (deviceControl == null)
+                //    return;
 
-                deviceControl.SaveXml();
+                //deviceControl.SaveXml();
 
-                //HACK: This is necessary to avoid the double-write race condition (viz. overwriting the keyfile twice 
-                //in quick succession, while BMS process is starting up and reading it).  We don't have a single
-                //"Document" class to encapsulate a conventional "dirty" flag, to know when we need to save user's
-                //work.  So for now, this ugly hackery.
-                if (bmsHasBeenLaunched == false)
-                    appReg.getOverrideWriter().SaveKeyMapping(inGameAxis, deviceControl);
+                ////HACK: This is necessary to avoid the double-write race condition (viz. overwriting the keyfile twice 
+                ////in quick succession, while BMS process is starting up and reading it).  We don't have a single
+                ////"Document" class to encapsulate a conventional "dirty" flag, to know when we need to save user's
+                ////work.  So for now, this ugly hackery.
+                //if (bmsHasBeenLaunched == false)
+                //    appReg.getOverrideWriter().SaveKeyMapping(inGameAxis, deviceControl);
             }
             catch (Exception ex)
             {
@@ -841,12 +841,12 @@ namespace FalconBMS.Launcher.Windows
                 string newVersion = this.ListBox_BMS.SelectedItem.ToString();
                 Properties.Settings.Default.BMS_Version = newVersion;
 
-                // Don't lose user's recent changes!
-                if (deviceControl != null)
-                {
-                    deviceControl.SaveXml();
-                    appReg.getOverrideWriter().SaveKeyMapping(inGameAxis, deviceControl);
-                }
+                //// Don't lose user's recent changes!
+                //if (deviceControl != null)
+                //{
+                //    deviceControl.SaveXml();
+                //    appReg.getOverrideWriter().SaveKeyMapping(inGameAxis, deviceControl);
+                //}
 
                 appReg.UpdateSelectedBMSVersion(newVersion);
 

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
+//using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -13,12 +13,12 @@ using FalconBMS.Launcher.Input;
 
 using MahApps.Metro.Controls;
 
-using AutoUpdaterDotNET;
-using System.Reflection;
-using System.Xml;
-using System.Threading.Tasks;
-using System.Collections.ObjectModel;
-using System.Linq;
+//using AutoUpdaterDotNET;
+//using System.Reflection;
+//using System.Xml;
+//using System.Threading.Tasks;
+//using System.Collections.ObjectModel;
+//using System.Linq;
 
 namespace FalconBMS.Launcher.Windows
 {
@@ -69,19 +69,19 @@ namespace FalconBMS.Launcher.Windows
                 System.Reflection.Assembly asm = System.Reflection.Assembly.GetExecutingAssembly();
                 System.Version ver = asm.GetName().Version;
 
-                // Defer auto-update check until after main window UI finishes initial layout and render.
-                this.Dispatcher.BeginInvoke(new Action(() => {
+                //// Defer auto-update check until after main window UI finishes initial layout and render.
+                //this.Dispatcher.BeginInvoke(new Action(() => {
 
-                    // NB: the AutoUpdaterDotNET library will create its own background (UI) thread, to do network I/O and display UI if necessary.
-                    string autoUpdateManifestUrl = $"https://cdn.falcon-bits.net/AutoUpdate/AL/v{ver}/AutoUpdate.xml";
+                //    // NB: the AutoUpdaterDotNET library will create its own background (UI) thread, to do network I/O and display UI if necessary.
+                //    string autoUpdateManifestUrl = $"https://cdn.falcon-bits.net/AutoUpdate/AL/v{ver}/AutoUpdate.xml";
 
-                    AutoUpdater.Mandatory = true;
-                    AutoUpdater.Synchronous = false;
-                    //AutoUpdater.Start("https://raw.githubusercontent.com/chihirobelmo/FalconBMS-Alternative-Launcher/master/Falcon%20BMS%20Alternative%20Launcher/AutoUpdate.xml", asm);
-                    AutoUpdater.Start(autoUpdateManifestUrl, asm);
+                //    AutoUpdater.Mandatory = true;
+                //    AutoUpdater.Synchronous = false;
+                //    //AutoUpdater.Start("https://raw.githubusercontent.com/chihirobelmo/FalconBMS-Alternative-Launcher/master/Falcon%20BMS%20Alternative%20Launcher/AutoUpdate.xml", asm);
+                //    AutoUpdater.Start(autoUpdateManifestUrl, asm);
 
-                    Diagnostics.Log("AutoUpdate-check initiated.");
-                }));
+                //    Diagnostics.Log("AutoUpdate-check initiated.");
+                //}));
 
                 string versionLabel = "FalconBMS Launcher v" + ver.ToString();
                 AL_Version_Number.Content = versionLabel;

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -69,17 +69,24 @@ namespace FalconBMS.Launcher.Windows
                 System.Reflection.Assembly asm = System.Reflection.Assembly.GetExecutingAssembly();
                 System.Version ver = asm.GetName().Version;
 
-                // NB: the AutoUpdaterDotNET library will create its own background (UI) thread, to do network I/O and display UI if necessary.
-                AutoUpdater.Mandatory = true;
-                AutoUpdater.Synchronous = false;
-                AutoUpdater.Start("https://raw.githubusercontent.com/chihirobelmo/FalconBMS-Alternative-Launcher/master/Falcon%20BMS%20Alternative%20Launcher/AutoUpdate.xml", asm);
-                
-                Diagnostics.Log("AutoUpdate-check initiated.");
+                // Defer auto-update check until after main window UI finishes initial layout and render.
+                this.Dispatcher.BeginInvoke(new Action(() => {
 
-                string BMS_Launcher_version = "FalconBMS Launcher v" + ver.Major + "." + ver.Minor + "." + ver.Build + "." + ver.Revision;
-                AL_Version_Number.Content = BMS_Launcher_version;
+                    // NB: the AutoUpdaterDotNET library will create its own background (UI) thread, to do network I/O and display UI if necessary.
+                    string autoUpdateManifestUrl = $"https://cdn.falcon-bits.net/AutoUpdate/AL/v{ver}/AutoUpdate.xml";
 
-                Diagnostics.Log(BMS_Launcher_version);
+                    AutoUpdater.Mandatory = true;
+                    AutoUpdater.Synchronous = false;
+                    //AutoUpdater.Start("https://raw.githubusercontent.com/chihirobelmo/FalconBMS-Alternative-Launcher/master/Falcon%20BMS%20Alternative%20Launcher/AutoUpdate.xml", asm);
+                    AutoUpdater.Start(autoUpdateManifestUrl, asm);
+
+                    Diagnostics.Log("AutoUpdate-check initiated.");
+                }));
+
+                string versionLabel = "FalconBMS Launcher v" + ver.ToString();
+                AL_Version_Number.Content = versionLabel;
+
+                Diagnostics.Log(versionLabel);
 
                 System.Threading.ThreadPool.QueueUserWorkItem(_ThreadPool_UpdateRss, this.Dispatcher);
             }

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowAxisAssign.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowAxisAssign.cs
@@ -360,6 +360,10 @@ namespace FalconBMS.Launcher.Windows
             joyAssign_2_inGameAxis();
             ResetAssgnWindow();
 
+            // Save the XML and Key files, after each change user makes.
+            MainWindow.deviceControl.SaveXml();
+            this.appReg.getOverrideWriter().SaveKeyMapping(MainWindow.inGameAxis, MainWindow.deviceControl);
+
             NewDeviceDetectTimer.Start();
             AxisMovingTimer.Start();
         }

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowAxisAssign.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowAxisAssign.cs
@@ -240,14 +240,7 @@ namespace FalconBMS.Launcher.Windows
             }
             catch (FileNotFoundException ex)
             {
-                Console.WriteLine(ex.Message);
-
-                StreamWriter sw = new StreamWriter(appReg.GetInstallDir() + "\\Error.txt", false, Encoding.GetEncoding("shift_jis"));
-                sw.Write(ex.Message);
-                sw.Close();
-
-                MessageBox.Show("Error Log Saved To " + appReg.GetInstallDir() + "\\Error.txt", "WARNING", MessageBoxButton.OK, MessageBoxImage.Information);
-
+                Diagnostics.Log(ex);
                 Close();
             }
         }

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
@@ -279,7 +279,7 @@ namespace FalconBMS.Launcher.Windows
 
                             target = joyAssgns[i].pov[ii].direction[povs[ii] / CommonConstants.POV45].GetCallback(pinkyStatus);
 
-                            string direction = joyAssgns[i].pov[ii].GetDirection(povs[ii]);
+                            string direction = joyAssgns[i].pov[ii].GetDirectionLabel(povs[ii]);
                             Label_AssgnStatus.Content = "POV" + (ii + 1) + "." + direction + "\t: " + joyAssgns[i].GetProductName();
                         }
                     }

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
@@ -175,6 +175,9 @@ namespace FalconBMS.Launcher.Windows
         /// <param name="e"></param>
         public void KeyMappingTimer_Tick(object sender, EventArgs e)
         {
+            if (!this.IsActive)
+                return;
+
             try
             {
                 directInputDevice.GetCurrentKeyboardState();
@@ -183,16 +186,9 @@ namespace FalconBMS.Launcher.Windows
                         KeyMappingGrid_KeyDown();
                 JumptoAssignedKey();
             }
-            catch (System.IO.FileNotFoundException ex)
+            catch (FileNotFoundException ex)
             {
-                Console.WriteLine(ex.Message);
-
-                System.IO.StreamWriter sw = new System.IO.StreamWriter(appReg.GetInstallDir() + "\\Error.txt", false, System.Text.Encoding.GetEncoding("shift_jis"));
-                sw.Write(ex.Message);
-                sw.Close();
-
-                MessageBox.Show("Error Log Saved To " + appReg.GetInstallDir() + "\\Error.txt", "WARNING", MessageBoxButton.OK, MessageBoxImage.Information);
-
+                Diagnostics.Log(ex);
                 Close();
             }
         }


### PR DESCRIPTION
- BUGFIX - P1 - gracefully handle registry permission errors .. code-cleanup to improve consistency of readonly vs readwrite registy access
- BUGFIX - P1 - array-bounds exception when attempting to load old DX32-era xml files
- BUGFIX - P1 - remove edge-case code which results in data-loss, if device-list changes
- BUGFIX - P1 - make startup codepath more deterministic; don't hide error messages behind main window
- BUGFIX - P1 - overly strict keyfile parser - ignore nonzero-unused fields
- BUGFIX - P2 - KeyMappingWindow.Close() doesn't discard button/pov changes .. CopyButtonsAndHatsFromCurrentProfile does copy-by-val instead of -by-ref
- BUGFIX - P2 - pilot-model flag persistence
- BUGFIX - P3 - key timer when window not active
- BUGFIX - P2 - shutdown before launching update, instead of minimize
- CHANGE - P2 - show warning/hint when key/button already bound