### PR TITLE
Several post-U3.2 fixes

### DIFF
--- a/Falcon BMS Alternative Launcher/AppRegInfo.cs
+++ b/Falcon BMS Alternative Launcher/AppRegInfo.cs
@@ -129,6 +129,8 @@ namespace FalconBMS.Launcher
             RegistryKey rk = Registry.LocalMachine.OpenSubKey(regName64, writable:false);
             if (rk == null) return false;
 
+            this.regName = regName64;
+
             this.installDir = (string)rk.GetValue("baseDir");
             if (String.IsNullOrEmpty(installDir)) return false;
 

--- a/Falcon BMS Alternative Launcher/Input/AxAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/AxAssgn.cs
@@ -9,7 +9,7 @@ namespace FalconBMS.Launcher.Input
     {
         // Member
         protected string axisName = "";     // ex:Roll, Pitch, Yaw etc...
-        protected DateTime assgnDate = DateTime.Parse("12/12/1998 12:00:00");
+        protected DateTime assgnDate = new DateTime(1998, 12, 12, 12, 0, 0);
         protected bool invert;
         protected AxCurve saturation = 0;
         protected AxCurve deadzone = 0;

--- a/Falcon BMS Alternative Launcher/Input/InGameAxAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/InGameAxAssgn.cs
@@ -12,7 +12,7 @@ namespace FalconBMS.Launcher.Input
         protected bool invert;
         protected AxCurve saturation = AxCurve.None;
         protected AxCurve deadzone = AxCurve.None;
-        protected DateTime assgnDate = DateTime.Parse("12/12/1998 12:00:00");
+        protected DateTime assgnDate = new DateTime(1998, 12, 12, 12, 0, 0);
 
         public InGameAxAssgn() { }
 


### PR DESCRIPTION
Bump version to v2.4.1.6

Fix crash on startup for some locales (Korean?) when attempting to parse hardcoded datetime.

Reduce CPU load of multiple concurrent timers.

Allow the default BMS pov-look behavior for unassigned pov-hat.

Fix compat with some 4.38 builds.
